### PR TITLE
Add cleanup for outsidePlayers in pollPlayers to remove stale entries

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -163,6 +163,15 @@ func (w *worker) pollPlayers(ctx context.Context) {
 					w.firstCoord.Delete(id)
 					return true
 				})
+				w.outsidePlayers.Range(func(id string, _ outsidePlayer) bool {
+					for _, player := range players.Players {
+						if player.Id == id {
+							return true
+						}
+					}
+					w.outsidePlayers.Delete(id)
+					return true
+				})
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION
Unlike firstCoord, there is no explicit cleanup mechanism in pollPlayers or elsewhere to remove outsidePlayers entries for players who disconnect from the server.